### PR TITLE
feat: Add native share functionality to PWA

### DIFF
--- a/pwa/app.js
+++ b/pwa/app.js
@@ -57,6 +57,7 @@ async function initDB() {
 function setupEventListeners() {
     document.getElementById('refresh-btn').addEventListener('click', refreshContent);
     document.getElementById('copy-btn').addEventListener('click', copyToClipboard);
+    document.getElementById('share-btn').addEventListener('click', shareContent); // Added share button listener
     
     window.addEventListener('online', () => updateOnlineStatus(true));
     window.addEventListener('offline', () => updateOnlineStatus(false));
@@ -364,4 +365,23 @@ function showStatus(message, type = 'info') {
     setTimeout(() => {
         indicator.classList.remove('show');
     }, 3000);
+}
+
+// Share Content Function
+async function shareContent() {
+    const content = document.getElementById('prompt-content').textContent;
+
+    if (navigator.share) {
+        try {
+            await navigator.share({
+                text: content,
+            });
+            showStatus('Content shared successfully!', 'online');
+        } catch (error) {
+            console.error('Error sharing:', error);
+            showStatus('Error sharing content', 'error');
+        }
+    } else {
+        showStatus('Share feature not supported on this browser.', 'info');
+    }
 }

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -56,6 +56,7 @@
             <section id="viewer-section" class="hidden">
                 <div id="prompt-content"></div>
                 <button id="copy-btn" class="primary-btn">Copy to Clipboard</button>
+                <button id="share-btn" class="primary-btn">Share</button>
             </section>
         </main>
         


### PR DESCRIPTION
This commit introduces a native share feature to the Prompt Viewer PWA.

Key changes:
- Added a "Share" button to `pwa/index.html` alongside the existing "Copy to Clipboard" button.
- Implemented a `shareContent` function in `pwa/app.js` that utilizes the Web Share API (`navigator.share`) to trigger the native mobile share screen.
- The function retrieves the text content from the currently displayed prompt.
- If the Web Share API is supported, it allows you to share the prompt content with other apps on your device.
- If the API is not supported (e.g., on desktop browsers), a message is displayed to you.
- Error handling is included for the share operation, and appropriate feedback is provided to you via status messages.
- The existing "Copy to Clipboard" functionality remains unaffected.

This enhancement improves the PWA's integration with mobile devices, offering a more native-like experience for sharing prompts.